### PR TITLE
Use refs to prevent order-of-initialization failures

### DIFF
--- a/include/cppqc/Arbitrary.h
+++ b/include/cppqc/Arbitrary.h
@@ -115,8 +115,8 @@ struct Arbitrary
     typedef boost::function<T (RngEngine &, std::size_t)> unGenType;
     typedef boost::function<std::vector<T> (T)> shrinkType;
 
-    static const unGenType unGen;
-    static const shrinkType shrink;
+    static const unGenType &unGen;
+    static const shrinkType &shrink;
 };
 
 /*
@@ -133,10 +133,10 @@ struct ArbitraryImpl
 };
 
 template<class T>
-const typename Arbitrary<T>::unGenType Arbitrary<T>::unGen =
+const typename Arbitrary<T>::unGenType &Arbitrary<T>::unGen =
 ArbitraryImpl<T>::unGen;
 template<class T>
-const typename Arbitrary<T>::shrinkType Arbitrary<T>::shrink =
+const typename Arbitrary<T>::shrinkType &Arbitrary<T>::shrink =
 ArbitraryImpl<T>::shrink;
 
 // included specializations


### PR DESCRIPTION
I ran into some very weird runtime errors (exceptions about trying to call empty `boost::function`s) using CppQuickCheck on Mac OS X (can supply more detail about tool/OS versions if you'd like). After some spelunking, I tried adding this before calling any cppqc functions:

```c++
std::cout << Arbitrary<int>::unGen.empty() << "\n";
std::cout << ArbitraryImpl<int>::unGen.empty() << "\n";
```

and much to my surprise, it printed "0 1". I'm a little out of my depth, but I think maybe this is an "order of initialization is undefined" issue, because I was able to run the examples without problems.

This PR fixes the issue by making `Arbitrary<T>::unGen` (and shrink) be references to `ArbitraryImpl<T>::unGen` (and shrink) instead of copies. I'm only just now starting to experiment with cppqc, so I'm not sure if this could cause other problems or if there's a better way to solve the problem.