### PR TITLE
Variadic templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ install_manifest.txt
 sampleOutput
 sampleShrinkOutput
 testReverse
+testReverseArray
 testSort
 libcppqc.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.6)
 project(CppQuickCheck)
-set(CMAKE_CXX_FLAGS "-O3 -g -Wall -std=gnu++11")
+set(CMAKE_CXX_FLAGS "-O3 -g -Wall -std=c++11")
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,4 +13,8 @@ target_link_libraries(testReverseArray cppqc)
 add_executable(testSort src/TestSort.cpp)
 target_link_libraries(testSort cppqc)
 
+# requires c++1y compile flag
+#add_executable(testBoostTupleSupport src/BoostTupleSupport.cpp)
+#target_link_libraries(testBoostTupleSupport cppqc)
+
 

--- a/examples/src/BoostTupleSupport.cpp
+++ b/examples/src/BoostTupleSupport.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2015, Gregory Rogers All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// It demonstrates how to add support for boost::tuple by
+// writing a custom generator (using std::tuple).
+//
+// Note this file uses C++14 features.
+
+#include "cppqc.h"
+
+#include <boost/tuple/tuple.hpp>
+#include "boost/tuple/tuple_comparison.hpp"
+#include <boost/tuple/tuple_io.hpp>
+#include <utility>
+
+using namespace cppqc;
+
+namespace {
+
+    template <typename StdTuple, std::size_t... Is>
+    auto asBoostTuple(StdTuple &&stdTuple, std::index_sequence<Is...>) {
+        return boost::tuple<std::tuple_element_t<Is, std::decay_t<StdTuple>>...>
+                            (std::get<Is>(std::forward<StdTuple>(stdTuple))...);
+    }
+
+    template <typename BoostTuple, std::size_t... Is>
+    auto asStdTuple(BoostTuple &&boostTuple, std::index_sequence<Is...>) {
+        return std::tuple<typename boost::tuples::element<Is, std::decay_t<BoostTuple>>::type...>
+                         (boost::get<Is>(std::forward<BoostTuple>(boostTuple))...);
+    }
+
+    template <typename StdTuple>
+    auto asBoostTuple(StdTuple &&stdTuple) {
+        return asBoostTuple(std::forward<StdTuple>(stdTuple),
+                 std::make_index_sequence<std::tuple_size<std::decay_t<StdTuple>>::value>());
+    }
+
+    template <typename BoostTuple>
+    auto asStdTuple(BoostTuple&& boostTuple) {
+        return asStdTuple(std::forward<BoostTuple>(boostTuple),
+                 std::make_index_sequence<boost::tuples::length<std::decay_t<BoostTuple>>::value>());
+    }
+
+    template<typename... T>
+    struct BoostTupleGenerator
+    {
+        BoostTupleGenerator(const Generator<T> &...g) :
+            m_tupleGenerator(tupleOf(g...))
+        {
+        }
+
+        boost::tuple<T...> unGen(RngEngine &rng, std::size_t size) const
+        {
+            return asBoostTuple(m_tupleGenerator.unGen(rng, size));
+        }
+
+        std::vector<boost::tuple<T...>> shrink(boost::tuple<T...> shrinkInput) const
+        {
+            std::vector<boost::tuple<T...>> result;
+            for (const auto &shrink : m_tupleGenerator.shrink(asStdTuple(shrinkInput))) {
+                result.push_back(asBoostTuple(shrink));
+            }
+            return result;
+        }
+
+    private:
+
+        Generator<std::tuple<T...>> m_tupleGenerator;
+    };
+
+}
+
+template<typename... T>
+Generator<boost::tuple<T...>> boostTupleOf(const Generator<T> &...g)
+{
+    return BoostTupleGenerator<T...>(g...);
+}
+
+template<typename... T>
+Generator<boost::tuple<T...>> boostTupleOf()
+{
+    return BoostTupleGenerator<T...>(Arbitrary<T>()...);
+}
+
+
+struct AntisymmetricRelationProp : Property<boost::tuple<int, std::string, int>,
+                                            boost::tuple<int, std::string, int>>
+{
+    AntisymmetricRelationProp() : Property(
+        boostTupleOf<int, std::string, int>(),
+        boostTupleOf<int, std::string, int>())
+    {}
+
+    bool check(const boost::tuple<int, std::string, int> &v1,
+               const boost::tuple<int, std::string, int> &v2) const override
+    {
+        return (v1 <= v2 && v1 >= v2) == (v1 == v2);
+    }
+
+    std::string name() const override
+    {
+        return "Comparison must be antisymmetric";
+    }
+};
+
+int main()
+{
+    cppqc::quickCheckOutput(AntisymmetricRelationProp());
+}

--- a/examples/src/TestReverse.cpp
+++ b/examples/src/TestReverse.cpp
@@ -26,7 +26,6 @@
 #include "cppqc.h"
 
 #include <algorithm>
-#include <boost/static_assert.hpp>
 #include <sstream>
 
 struct PropTestReverse : cppqc::Property<std::vector<int>>

--- a/examples/src/sampleOutput.cpp
+++ b/examples/src/sampleOutput.cpp
@@ -28,7 +28,6 @@
 #include <map>
 #include <boost/bind.hpp>
 #include <boost/assign/list_of.hpp>
-#include <boost/tuple/tuple_io.hpp>
 
 using namespace cppqc;
 
@@ -54,7 +53,7 @@ sampleOutputCommand = boost::assign::map_list_of<std::string, boost::function<vo
 ("double",         boost::bind(sampleOutput<double>,              Arbitrary<double>(),              boost::ref(std::cout), 0, 0))
 ("long double",    boost::bind(sampleOutput<long double>,         Arbitrary<long double>(),         boost::ref(std::cout), 0, 0))
 ("pair",           boost::bind(sampleOutput<std::pair<int,int> >, Arbitrary<std::pair<int,int> >(), boost::ref(std::cout), 0, 0))
-("tuple",          boost::bind(sampleOutput<boost::tuple<int,int,int> >, tupleOf<int,int,int>(),    boost::ref(std::cout), 0, 0))
+("tuple",          boost::bind(sampleOutput<std::tuple<int,int,int> >, tupleOf<int,int,int>(),    boost::ref(std::cout), 0, 0))
 ("string",         boost::bind(sampleOutput<std::string>,         Arbitrary<std::string>(),         boost::ref(std::cout), 0, 0));
 
 int main(int argc, char **argv)

--- a/examples/src/sampleShrinkOutput.cpp
+++ b/examples/src/sampleShrinkOutput.cpp
@@ -28,7 +28,6 @@
 #include <map>
 #include <boost/bind.hpp>
 #include <boost/assign/list_of.hpp>
-#include <boost/tuple/tuple_io.hpp>
 
 using namespace cppqc;
 
@@ -62,11 +61,16 @@ sampleShrinkOutputCommand = boost::assign::map_list_of<std::string, boost::funct
 ("double",         boost::bind(sampleShrinkOutput<double>,              Arbitrary<double>(),              boost::ref(std::cout), 0, true, 0))
 ("long double",    boost::bind(sampleShrinkOutput<long double>,         Arbitrary<long double>(),         boost::ref(std::cout), 0, true, 0))
 ("pair",           boost::bind(sampleShrinkOutput<std::pair<int,int> >, Arbitrary<std::pair<int,int> >(), boost::ref(std::cout), 0, true, 0))
-("tuple",          boost::bind(sampleShrinkOutput<boost::tuple<int,int,int> >, tupleOf<int,int,int>(),    boost::ref(std::cout), 0, true, 0))
+("tuple",          boost::bind(sampleShrinkOutput<std::tuple<int,int,int> >, tupleOf<int,int,int>(),    boost::ref(std::cout), 0, true, 0))
 ("string",         boost::bind(sampleShrinkOutput<std::string>,         Arbitrary<std::string>(),         boost::ref(std::cout), 0, true, 0));
 
 int main(int argc, char **argv)
 {
+    if(argc == 1) {
+        std::cout << "Usage: TYPES... (e.g., int, double, string)\n";
+        return 0;
+    }
+
     for (int i = 1; i < argc; ++i) {
         std::map<std::string, boost::function<void ()> >::const_iterator it =
             sampleShrinkOutputCommand.find(argv[i]);

--- a/include/cppqc/Arbitrary.h
+++ b/include/cppqc/Arbitrary.h
@@ -298,7 +298,7 @@ std::vector<String> shrinkString(const String &x)
 {
     std::vector<String> ret;
     ret.reserve(x.size());
-    for (typename String::const_iterator it = x.begin(); it != x.end(); ++it) {
+    for (auto it = x.begin(); it != x.end(); ++it) {
         ret.push_back(String());
         ret.back().reserve(x.size() - 1);
         ret.back().insert(ret.back().end(), x.begin(), it);
@@ -338,12 +338,10 @@ std::vector<PairType> shrinkPair(const PairType &x)
     std::vector<SecondType> shrinks2 = Arbitrary<SecondType>::shrink(x.second);
     std::vector<PairType> ret;
     ret.reserve(shrinks1.size() + shrinks2.size());
-    for (typename std::vector<FirstType>::const_iterator it = shrinks1.begin();
-            it != shrinks1.end(); ++it) {
+    for (auto it = shrinks1.begin(); it != shrinks1.end(); ++it) {
         ret.push_back(PairType(*it, x.second));
     }
-    for (typename std::vector<SecondType>::const_iterator it = shrinks2.begin();
-            it != shrinks2.end(); ++it) {
+    for (auto it = shrinks2.begin(); it != shrinks2.end(); ++it) {
         ret.push_back(PairType(x.first, *it));
     }
     return ret;

--- a/include/cppqc/Generator.h
+++ b/include/cppqc/Generator.h
@@ -29,7 +29,8 @@
 #include <boost/function.hpp>
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/mersenne_twister.hpp>
-#include <boost/tuple/tuple.hpp>
+#include <tuple>
+#include <utility>
 #include <cstddef>
 #include <iosfwd>
 #include <vector>
@@ -71,6 +72,7 @@ template<class T> struct Arbitrary;
 
 
 namespace detail {
+
     template<class T>
     struct GenConcept
     {
@@ -1228,889 +1230,112 @@ StatelessGenerator<std::vector<T> > vectorOf(std::size_t size,
 
 
 namespace detail {
-    struct null_type {};
 
-    template<class T0, class T1 = null_type, class T2 = null_type,
-        class T3 = null_type, class T4 = null_type, class T5 = null_type,
-        class T6 = null_type, class T7 = null_type, class T8 = null_type,
-        class T9 = null_type>
-    class TupleGenerator
+    template<int offset, typename T, typename... Ts>
+    struct TupleGeneratorHelper_unGen
     {
-            typedef boost::tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>
-                tuple_type;
-        public:
-            TupleGenerator(const Generator<T0> &g0, const Generator<T1> &g1,
-                    const Generator<T2> &g2, const Generator<T3> &g3,
-                    const Generator<T4> &g4, const Generator<T5> &g5,
-                    const Generator<T6> &g6, const Generator<T7> &g7,
-                    const Generator<T8> &g8, const Generator<T9> &g9) :
-                m_gen0(g0), m_gen1(g1), m_gen2(g2), m_gen3(g3), m_gen4(g4),
-                m_gen5(g5), m_gen6(g6), m_gen7(g7), m_gen8(g8), m_gen9(g9)
-            {
-            }
-
-            tuple_type unGen(RngEngine &rng, std::size_t size)
-            {
-                return tuple_type(m_gen0.unGen(rng, size),
-                        m_gen1.unGen(rng, size), m_gen2.unGen(rng, size),
-                        m_gen3.unGen(rng, size), m_gen4.unGen(rng, size),
-                        m_gen5.unGen(rng, size), m_gen6.unGen(rng, size),
-                        m_gen7.unGen(rng, size), m_gen8.unGen(rng, size),
-                        m_gen9.unGen(rng, size));
-            }
-
-            std::vector<tuple_type> shrink(const tuple_type &x)
-            {
-                std::vector<T0> shrinks0 = m_gen0.shrink(boost::get<0>(x));
-                std::vector<T1> shrinks1 = m_gen1.shrink(boost::get<1>(x));
-                std::vector<T2> shrinks2 = m_gen2.shrink(boost::get<2>(x));
-                std::vector<T3> shrinks3 = m_gen3.shrink(boost::get<3>(x));
-                std::vector<T4> shrinks4 = m_gen4.shrink(boost::get<4>(x));
-                std::vector<T5> shrinks5 = m_gen5.shrink(boost::get<5>(x));
-                std::vector<T6> shrinks6 = m_gen6.shrink(boost::get<6>(x));
-                std::vector<T7> shrinks7 = m_gen7.shrink(boost::get<7>(x));
-                std::vector<T8> shrinks8 = m_gen8.shrink(boost::get<8>(x));
-                std::vector<T9> shrinks9 = m_gen9.shrink(boost::get<9>(x));
-                std::vector<tuple_type> ret;
-                ret.reserve(shrinks0.size() + shrinks1.size() +
-                        shrinks2.size() + shrinks3.size() + shrinks4.size() +
-                        shrinks5.size() + shrinks6.size() + shrinks7.size() +
-                        shrinks8.size() + shrinks9.size());
-                for (typename std::vector<T0>::const_iterator it =
-                        shrinks0.begin(); it != shrinks0.end(); ++it)
-                    ret.push_back(tuple_type(*it, boost::get<1>(x),
-                                boost::get<2>(x), boost::get<3>(x),
-                                boost::get<4>(x), boost::get<5>(x),
-                                boost::get<6>(x), boost::get<7>(x),
-                                boost::get<8>(x), boost::get<9>(x)));
-                for (typename std::vector<T1>::const_iterator it =
-                        shrinks1.begin(); it != shrinks1.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x), *it,
-                                boost::get<2>(x), boost::get<3>(x),
-                                boost::get<4>(x), boost::get<5>(x),
-                                boost::get<6>(x), boost::get<7>(x),
-                                boost::get<8>(x), boost::get<9>(x)));
-                for (typename std::vector<T2>::const_iterator it =
-                        shrinks2.begin(); it != shrinks2.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), *it, boost::get<3>(x),
-                                boost::get<4>(x), boost::get<5>(x),
-                                boost::get<6>(x), boost::get<7>(x),
-                                boost::get<8>(x), boost::get<9>(x)));
-                for (typename std::vector<T3>::const_iterator it =
-                        shrinks3.begin(); it != shrinks3.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x), *it,
-                                boost::get<4>(x), boost::get<5>(x),
-                                boost::get<6>(x), boost::get<7>(x),
-                                boost::get<8>(x), boost::get<9>(x)));
-                for (typename std::vector<T4>::const_iterator it =
-                        shrinks4.begin(); it != shrinks4.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), *it, boost::get<5>(x),
-                                boost::get<6>(x), boost::get<7>(x),
-                                boost::get<8>(x), boost::get<9>(x)));
-                for (typename std::vector<T5>::const_iterator it =
-                        shrinks5.begin(); it != shrinks5.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), boost::get<4>(x), *it,
-                                boost::get<6>(x), boost::get<7>(x),
-                                boost::get<8>(x), boost::get<9>(x)));
-                for (typename std::vector<T6>::const_iterator it =
-                        shrinks6.begin(); it != shrinks6.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), boost::get<4>(x),
-                                boost::get<5>(x), *it, boost::get<7>(x),
-                                boost::get<8>(x), boost::get<9>(x)));
-                for (typename std::vector<T7>::const_iterator it =
-                        shrinks7.begin(); it != shrinks7.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), boost::get<4>(x),
-                                boost::get<5>(x), boost::get<6>(x), *it,
-                                boost::get<8>(x), boost::get<9>(x)));
-                for (typename std::vector<T8>::const_iterator it =
-                        shrinks8.begin(); it != shrinks8.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), boost::get<4>(x),
-                                boost::get<5>(x), boost::get<6>(x),
-                                boost::get<7>(x), *it, boost::get<9>(x)));
-                for (typename std::vector<T9>::const_iterator it =
-                        shrinks9.begin(); it != shrinks9.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), boost::get<4>(x),
-                                boost::get<5>(x), boost::get<6>(x),
-                                boost::get<7>(x), boost::get<8>(x), *it));
-                return ret;
-            }
-
-        private:
-            const Generator<T0> m_gen0;
-            const Generator<T1> m_gen1;
-            const Generator<T2> m_gen2;
-            const Generator<T3> m_gen3;
-            const Generator<T4> m_gen4;
-            const Generator<T5> m_gen5;
-            const Generator<T6> m_gen6;
-            const Generator<T7> m_gen7;
-            const Generator<T8> m_gen8;
-            const Generator<T9> m_gen9;
+        template <typename Generators>
+        static std::tuple<T, Ts...> unGen(RngEngine &rng, std::size_t size,
+                                          const Generators &generators)
+        {
+            return std::tuple_cat(
+                std::make_tuple(std::get<offset>(generators).unGen(rng, size)),
+                TupleGeneratorHelper_unGen<
+                    offset + 1, Ts...>::unGen(rng, size, generators));
+        }
     };
 
-    template<class T0, class T1, class T2, class T3, class T4,
-        class T5, class T6, class T7, class T8>
-    class TupleGenerator<T0, T1, T2, T3, T4, T5, T6, T7, T8, null_type>
+    template<int offset, typename T>
+    struct TupleGeneratorHelper_unGen<offset, T>
     {
-            typedef boost::tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8> tuple_type;
-        public:
-            TupleGenerator(const Generator<T0> &g0, const Generator<T1> &g1,
-                    const Generator<T2> &g2, const Generator<T3> &g3,
-                    const Generator<T4> &g4, const Generator<T5> &g5,
-                    const Generator<T6> &g6, const Generator<T7> &g7,
-                    const Generator<T8> &g8) :
-                m_gen0(g0), m_gen1(g1), m_gen2(g2), m_gen3(g3), m_gen4(g4),
-                m_gen5(g5), m_gen6(g6), m_gen7(g7), m_gen8(g8)
-            {
-            }
-
-            tuple_type unGen(RngEngine &rng, std::size_t size)
-            {
-                return tuple_type(m_gen0.unGen(rng, size),
-                        m_gen1.unGen(rng, size), m_gen2.unGen(rng, size),
-                        m_gen3.unGen(rng, size), m_gen4.unGen(rng, size),
-                        m_gen5.unGen(rng, size), m_gen6.unGen(rng, size),
-                        m_gen7.unGen(rng, size), m_gen8.unGen(rng, size));
-            }
-
-            std::vector<tuple_type> shrink(const tuple_type &x)
-            {
-                std::vector<T0> shrinks0 = m_gen0.shrink(boost::get<0>(x));
-                std::vector<T1> shrinks1 = m_gen1.shrink(boost::get<1>(x));
-                std::vector<T2> shrinks2 = m_gen2.shrink(boost::get<2>(x));
-                std::vector<T3> shrinks3 = m_gen3.shrink(boost::get<3>(x));
-                std::vector<T4> shrinks4 = m_gen4.shrink(boost::get<4>(x));
-                std::vector<T5> shrinks5 = m_gen5.shrink(boost::get<5>(x));
-                std::vector<T6> shrinks6 = m_gen6.shrink(boost::get<6>(x));
-                std::vector<T7> shrinks7 = m_gen7.shrink(boost::get<7>(x));
-                std::vector<T8> shrinks8 = m_gen8.shrink(boost::get<8>(x));
-                std::vector<tuple_type> ret;
-                ret.reserve(shrinks0.size() + shrinks1.size() +
-                        shrinks2.size() + shrinks3.size() + shrinks4.size() +
-                        shrinks5.size() + shrinks6.size() + shrinks7.size() +
-                        shrinks8.size());
-                for (typename std::vector<T0>::const_iterator it =
-                        shrinks0.begin(); it != shrinks0.end(); ++it)
-                    ret.push_back(tuple_type(*it, boost::get<1>(x),
-                                boost::get<2>(x), boost::get<3>(x),
-                                boost::get<4>(x), boost::get<5>(x),
-                                boost::get<6>(x), boost::get<7>(x),
-                                boost::get<8>(x)));
-                for (typename std::vector<T1>::const_iterator it =
-                        shrinks1.begin(); it != shrinks1.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x), *it,
-                                boost::get<2>(x), boost::get<3>(x),
-                                boost::get<4>(x), boost::get<5>(x),
-                                boost::get<6>(x), boost::get<7>(x),
-                                boost::get<8>(x)));
-                for (typename std::vector<T2>::const_iterator it =
-                        shrinks2.begin(); it != shrinks2.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), *it, boost::get<3>(x),
-                                boost::get<4>(x), boost::get<5>(x),
-                                boost::get<6>(x), boost::get<7>(x),
-                                boost::get<8>(x)));
-                for (typename std::vector<T3>::const_iterator it =
-                        shrinks3.begin(); it != shrinks3.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x), *it,
-                                boost::get<4>(x), boost::get<5>(x),
-                                boost::get<6>(x), boost::get<7>(x),
-                                boost::get<8>(x)));
-                for (typename std::vector<T4>::const_iterator it =
-                        shrinks4.begin(); it != shrinks4.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), *it, boost::get<5>(x),
-                                boost::get<6>(x), boost::get<7>(x),
-                                boost::get<8>(x)));
-                for (typename std::vector<T5>::const_iterator it =
-                        shrinks5.begin(); it != shrinks5.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), boost::get<4>(x), *it,
-                                boost::get<6>(x), boost::get<7>(x),
-                                boost::get<8>(x)));
-                for (typename std::vector<T6>::const_iterator it =
-                        shrinks6.begin(); it != shrinks6.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), boost::get<4>(x),
-                                boost::get<5>(x), *it, boost::get<7>(x),
-                                boost::get<8>(x)));
-                for (typename std::vector<T7>::const_iterator it =
-                        shrinks7.begin(); it != shrinks7.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), boost::get<4>(x),
-                                boost::get<5>(x), boost::get<6>(x), *it,
-                                boost::get<8>(x)));
-                for (typename std::vector<T8>::const_iterator it =
-                        shrinks8.begin(); it != shrinks8.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), boost::get<4>(x),
-                                boost::get<5>(x), boost::get<6>(x),
-                                boost::get<7>(x), *it));
-                return ret;
-            }
-
-        private:
-            const Generator<T0> m_gen0;
-            const Generator<T1> m_gen1;
-            const Generator<T2> m_gen2;
-            const Generator<T3> m_gen3;
-            const Generator<T4> m_gen4;
-            const Generator<T5> m_gen5;
-            const Generator<T6> m_gen6;
-            const Generator<T7> m_gen7;
-            const Generator<T8> m_gen8;
+        template <typename Generators>
+        static std::tuple<T> unGen(RngEngine &rng, std::size_t size,
+                                   const Generators &generators)
+        {
+            return std::tuple<T>(std::get<offset>(generators).unGen(rng, size));
+        }
     };
 
-    template<class T0, class T1, class T2, class T3, class T4,
-        class T5, class T6, class T7>
-    class TupleGenerator<T0, T1, T2, T3, T4, T5, T6, T7, null_type, null_type>
+    template<int offset, typename... T>
+    struct TupleGeneratorHelper_shrink
     {
-            typedef boost::tuple<T0, T1, T2, T3, T4, T5, T6, T7> tuple_type;
-        public:
-            TupleGenerator(const Generator<T0> &g0, const Generator<T1> &g1,
-                    const Generator<T2> &g2, const Generator<T3> &g3,
-                    const Generator<T4> &g4, const Generator<T5> &g5,
-                    const Generator<T6> &g6, const Generator<T7> &g7) :
-                m_gen0(g0), m_gen1(g1), m_gen2(g2), m_gen3(g3), m_gen4(g4),
-                m_gen5(g5), m_gen6(g6), m_gen7(g7)
-            {
+        template <typename Generators>
+        static void appendShrinks(const std::tuple<T...> &shrinkInput,
+                                  std::vector<std::tuple<T...>>& shrinkOutput,
+                                  const Generators &generators)
+        {
+            // Compute all shrink combinations for the tuple
+            // element at the position "offset".
+            // All other elements will not be changed.
+            static_assert(offset >= 0 && offset < sizeof...(T),
+                          "offset out of bounds");
+            auto allLocalShrinks =
+                std::get<offset>(generators).shrink(std::get<offset>(shrinkInput));
+            for (auto&& localShrink : allLocalShrinks) {
+                auto copiedShrinkInput = shrinkInput;
+                std::get<offset>(copiedShrinkInput) = std::move(localShrink);
+                shrinkOutput.push_back(std::move(copiedShrinkInput));
             }
 
-            tuple_type unGen(RngEngine &rng, std::size_t size)
-            {
-                return tuple_type(m_gen0.unGen(rng, size),
-                        m_gen1.unGen(rng, size), m_gen2.unGen(rng, size),
-                        m_gen3.unGen(rng, size), m_gen4.unGen(rng, size),
-                        m_gen5.unGen(rng, size), m_gen6.unGen(rng, size),
-                        m_gen7.unGen(rng, size));
-            }
-
-            std::vector<tuple_type> shrink(const tuple_type &x)
-            {
-                std::vector<T0> shrinks0 = m_gen0.shrink(boost::get<0>(x));
-                std::vector<T1> shrinks1 = m_gen1.shrink(boost::get<1>(x));
-                std::vector<T2> shrinks2 = m_gen2.shrink(boost::get<2>(x));
-                std::vector<T3> shrinks3 = m_gen3.shrink(boost::get<3>(x));
-                std::vector<T4> shrinks4 = m_gen4.shrink(boost::get<4>(x));
-                std::vector<T5> shrinks5 = m_gen5.shrink(boost::get<5>(x));
-                std::vector<T6> shrinks6 = m_gen6.shrink(boost::get<6>(x));
-                std::vector<T7> shrinks7 = m_gen7.shrink(boost::get<7>(x));
-                std::vector<tuple_type> ret;
-                ret.reserve(shrinks0.size() + shrinks1.size() +
-                        shrinks2.size() + shrinks3.size() + shrinks4.size() +
-                        shrinks5.size() + shrinks6.size() + shrinks7.size());
-                for (typename std::vector<T0>::const_iterator it =
-                        shrinks0.begin(); it != shrinks0.end(); ++it)
-                    ret.push_back(tuple_type(*it, boost::get<1>(x),
-                                boost::get<2>(x), boost::get<3>(x),
-                                boost::get<4>(x), boost::get<5>(x),
-                                boost::get<6>(x), boost::get<7>(x)));
-                for (typename std::vector<T1>::const_iterator it =
-                        shrinks1.begin(); it != shrinks1.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x), *it,
-                                boost::get<2>(x), boost::get<3>(x),
-                                boost::get<4>(x), boost::get<5>(x),
-                                boost::get<6>(x), boost::get<7>(x)));
-                for (typename std::vector<T2>::const_iterator it =
-                        shrinks2.begin(); it != shrinks2.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), *it, boost::get<3>(x),
-                                boost::get<4>(x), boost::get<5>(x),
-                                boost::get<6>(x), boost::get<7>(x)));
-                for (typename std::vector<T3>::const_iterator it =
-                        shrinks3.begin(); it != shrinks3.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x), *it,
-                                boost::get<4>(x), boost::get<5>(x),
-                                boost::get<6>(x), boost::get<7>(x)));
-                for (typename std::vector<T4>::const_iterator it =
-                        shrinks4.begin(); it != shrinks4.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), *it, boost::get<5>(x),
-                                boost::get<6>(x), boost::get<7>(x)));
-                for (typename std::vector<T5>::const_iterator it =
-                        shrinks5.begin(); it != shrinks5.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), boost::get<4>(x), *it,
-                                boost::get<6>(x), boost::get<7>(x)));
-                for (typename std::vector<T6>::const_iterator it =
-                        shrinks6.begin(); it != shrinks6.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), boost::get<4>(x),
-                                boost::get<5>(x), *it, boost::get<7>(x)));
-                for (typename std::vector<T7>::const_iterator it =
-                        shrinks7.begin(); it != shrinks7.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), boost::get<4>(x),
-                                boost::get<5>(x), boost::get<6>(x), *it));
-                return ret;
-            }
-
-        private:
-            const Generator<T0> m_gen0;
-            const Generator<T1> m_gen1;
-            const Generator<T2> m_gen2;
-            const Generator<T3> m_gen3;
-            const Generator<T4> m_gen4;
-            const Generator<T5> m_gen5;
-            const Generator<T6> m_gen6;
-            const Generator<T7> m_gen7;
+            // continue recursion (for right to left)
+            TupleGeneratorHelper_shrink<offset - 1, T...>::appendShrinks(
+                shrinkInput, shrinkOutput, generators);
+        }
     };
 
-    template<class T0, class T1, class T2, class T3, class T4,
-        class T5, class T6>
-    class TupleGenerator<T0, T1, T2, T3, T4, T5, T6,
-        null_type, null_type, null_type>
+    template<typename... T>
+    struct TupleGeneratorHelper_shrink<-1, T...>
     {
-            typedef boost::tuple<T0, T1, T2, T3, T4, T5, T6> tuple_type;
-        public:
-            TupleGenerator(const Generator<T0> &g0, const Generator<T1> &g1,
-                    const Generator<T2> &g2, const Generator<T3> &g3,
-                    const Generator<T4> &g4, const Generator<T5> &g5,
-                    const Generator<T6> &g6) :
-                m_gen0(g0), m_gen1(g1), m_gen2(g2), m_gen3(g3), m_gen4(g4),
-                m_gen5(g5), m_gen6(g6)
-            {
-            }
-
-            tuple_type unGen(RngEngine &rng, std::size_t size)
-            {
-                return tuple_type(m_gen0.unGen(rng, size),
-                        m_gen1.unGen(rng, size), m_gen2.unGen(rng, size),
-                        m_gen3.unGen(rng, size), m_gen4.unGen(rng, size),
-                        m_gen5.unGen(rng, size), m_gen6.unGen(rng, size));
-            }
-
-            std::vector<tuple_type> shrink(const tuple_type &x)
-            {
-                std::vector<T0> shrinks0 = m_gen0.shrink(boost::get<0>(x));
-                std::vector<T1> shrinks1 = m_gen1.shrink(boost::get<1>(x));
-                std::vector<T2> shrinks2 = m_gen2.shrink(boost::get<2>(x));
-                std::vector<T3> shrinks3 = m_gen3.shrink(boost::get<3>(x));
-                std::vector<T4> shrinks4 = m_gen4.shrink(boost::get<4>(x));
-                std::vector<T5> shrinks5 = m_gen5.shrink(boost::get<5>(x));
-                std::vector<T6> shrinks6 = m_gen6.shrink(boost::get<6>(x));
-                std::vector<tuple_type> ret;
-                ret.reserve(shrinks0.size() + shrinks1.size() +
-                        shrinks2.size() + shrinks3.size() + shrinks4.size() +
-                        shrinks5.size() + shrinks6.size());
-                for (typename std::vector<T0>::const_iterator it =
-                        shrinks0.begin(); it != shrinks0.end(); ++it)
-                    ret.push_back(tuple_type(*it, boost::get<1>(x),
-                                boost::get<2>(x), boost::get<3>(x),
-                                boost::get<4>(x), boost::get<5>(x),
-                                boost::get<6>(x)));
-                for (typename std::vector<T1>::const_iterator it =
-                        shrinks1.begin(); it != shrinks1.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x), *it,
-                                boost::get<2>(x), boost::get<3>(x),
-                                boost::get<4>(x), boost::get<5>(x),
-                                boost::get<6>(x)));
-                for (typename std::vector<T2>::const_iterator it =
-                        shrinks2.begin(); it != shrinks2.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), *it, boost::get<3>(x),
-                                boost::get<4>(x), boost::get<5>(x),
-                                boost::get<6>(x)));
-                for (typename std::vector<T3>::const_iterator it =
-                        shrinks3.begin(); it != shrinks3.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x), *it,
-                                boost::get<4>(x), boost::get<5>(x),
-                                boost::get<6>(x)));
-                for (typename std::vector<T4>::const_iterator it =
-                        shrinks4.begin(); it != shrinks4.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), *it, boost::get<5>(x),
-                                boost::get<6>(x)));
-                for (typename std::vector<T5>::const_iterator it =
-                        shrinks5.begin(); it != shrinks5.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), boost::get<4>(x), *it,
-                                boost::get<6>(x)));
-                for (typename std::vector<T6>::const_iterator it =
-                        shrinks6.begin(); it != shrinks6.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), boost::get<4>(x),
-                                boost::get<5>(x), *it));
-                return ret;
-            }
-
-        private:
-            const Generator<T0> m_gen0;
-            const Generator<T1> m_gen1;
-            const Generator<T2> m_gen2;
-            const Generator<T3> m_gen3;
-            const Generator<T4> m_gen4;
-            const Generator<T5> m_gen5;
-            const Generator<T6> m_gen6;
+        template <typename Generators>
+        static void appendShrinks(const std::tuple<T...> & /*shrinkInput*/,
+                                  std::vector<std::tuple<T...>> & /*shrinkOutput*/,
+                                  const Generators & /*generators*/)
+        {
+            // nothing to do (end of recursion)
+        }
     };
 
-    template<class T0, class T1, class T2, class T3, class T4,
-        class T5>
-    class TupleGenerator<T0, T1, T2, T3, T4, T5,
-        null_type, null_type, null_type, null_type>
+    template<typename... T>
+    struct TupleGenerator
     {
-            typedef boost::tuple<T0, T1, T2, T3, T4, T5> tuple_type;
-        public:
-            TupleGenerator(const Generator<T0> &g0, const Generator<T1> &g1,
-                    const Generator<T2> &g2, const Generator<T3> &g3,
-                    const Generator<T4> &g4, const Generator<T5> &g5) :
-                m_gen0(g0), m_gen1(g1), m_gen2(g2), m_gen3(g3), m_gen4(g4),
-                m_gen5(g5)
-            {
-            }
+        TupleGenerator(const Generator<T> &...g) :
+            m_gen(g...)
+        {
+        }
 
-            tuple_type unGen(RngEngine &rng, std::size_t size)
-            {
-                return tuple_type(m_gen0.unGen(rng, size),
-                        m_gen1.unGen(rng, size), m_gen2.unGen(rng, size),
-                        m_gen3.unGen(rng, size), m_gen4.unGen(rng, size),
-                        m_gen5.unGen(rng, size));
-            }
+        std::tuple<T...> unGen(RngEngine &rng, std::size_t size) const
+        {
+            return TupleGeneratorHelper_unGen<0, T...>::unGen(rng, size, m_gen);
+        }
 
-            std::vector<tuple_type> shrink(const tuple_type &x)
-            {
-                std::vector<T0> shrinks0 = m_gen0.shrink(boost::get<0>(x));
-                std::vector<T1> shrinks1 = m_gen1.shrink(boost::get<1>(x));
-                std::vector<T2> shrinks2 = m_gen2.shrink(boost::get<2>(x));
-                std::vector<T3> shrinks3 = m_gen3.shrink(boost::get<3>(x));
-                std::vector<T4> shrinks4 = m_gen4.shrink(boost::get<4>(x));
-                std::vector<T5> shrinks5 = m_gen5.shrink(boost::get<5>(x));
-                std::vector<tuple_type> ret;
-                ret.reserve(shrinks0.size() + shrinks1.size() +
-                        shrinks2.size() + shrinks3.size() + shrinks4.size() +
-                        shrinks5.size());
-                for (typename std::vector<T0>::const_iterator it =
-                        shrinks0.begin(); it != shrinks0.end(); ++it)
-                    ret.push_back(tuple_type(*it, boost::get<1>(x),
-                                boost::get<2>(x), boost::get<3>(x),
-                                boost::get<4>(x), boost::get<5>(x)));
-                for (typename std::vector<T1>::const_iterator it =
-                        shrinks1.begin(); it != shrinks1.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x), *it,
-                                boost::get<2>(x), boost::get<3>(x),
-                                boost::get<4>(x), boost::get<5>(x)));
-                for (typename std::vector<T2>::const_iterator it =
-                        shrinks2.begin(); it != shrinks2.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), *it, boost::get<3>(x),
-                                boost::get<4>(x), boost::get<5>(x)));
-                for (typename std::vector<T3>::const_iterator it =
-                        shrinks3.begin(); it != shrinks3.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x), *it,
-                                boost::get<4>(x), boost::get<5>(x)));
-                for (typename std::vector<T4>::const_iterator it =
-                        shrinks4.begin(); it != shrinks4.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), *it, boost::get<5>(x)));
-                for (typename std::vector<T5>::const_iterator it =
-                        shrinks5.begin(); it != shrinks5.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), boost::get<4>(x), *it));
-                return ret;
-            }
+        std::vector<std::tuple<T...>> shrink(const std::tuple<T...> &shrinkInput) const
+        {
+            std::vector<std::tuple<T...>> shrinkOutput;
+            constexpr auto last_index = sizeof...(T) - 1;
+            TupleGeneratorHelper_shrink<last_index, T...>::appendShrinks(
+                shrinkInput, shrinkOutput, m_gen);
+            return shrinkOutput;
+        }
 
-        private:
-            const Generator<T0> m_gen0;
-            const Generator<T1> m_gen1;
-            const Generator<T2> m_gen2;
-            const Generator<T3> m_gen3;
-            const Generator<T4> m_gen4;
-            const Generator<T5> m_gen5;
+    private:
+        std::tuple<Generator<T>...> m_gen;
     };
 
-    template<class T0, class T1, class T2, class T3, class T4>
-    class TupleGenerator<T0, T1, T2, T3, T4,
-          null_type, null_type, null_type, null_type, null_type>
-    {
-            typedef boost::tuple<T0, T1, T2, T3, T4> tuple_type;
-        public:
-            TupleGenerator(const Generator<T0> &g0, const Generator<T1> &g1,
-                    const Generator<T2> &g2, const Generator<T3> &g3,
-                    const Generator<T4> &g4) :
-                m_gen0(g0), m_gen1(g1), m_gen2(g2), m_gen3(g3), m_gen4(g4)
-            {
-            }
-
-            tuple_type unGen(RngEngine &rng, std::size_t size)
-            {
-                return tuple_type(m_gen0.unGen(rng, size),
-                        m_gen1.unGen(rng, size), m_gen2.unGen(rng, size),
-                        m_gen3.unGen(rng, size), m_gen4.unGen(rng, size));
-            }
-
-            std::vector<tuple_type> shrink(const tuple_type &x)
-            {
-                std::vector<T0> shrinks0 = m_gen0.shrink(boost::get<0>(x));
-                std::vector<T1> shrinks1 = m_gen1.shrink(boost::get<1>(x));
-                std::vector<T2> shrinks2 = m_gen2.shrink(boost::get<2>(x));
-                std::vector<T3> shrinks3 = m_gen3.shrink(boost::get<3>(x));
-                std::vector<T4> shrinks4 = m_gen4.shrink(boost::get<4>(x));
-                std::vector<tuple_type> ret;
-                ret.reserve(shrinks0.size() + shrinks1.size() +
-                        shrinks2.size() + shrinks3.size() + shrinks4.size());
-                for (typename std::vector<T0>::const_iterator it =
-                        shrinks0.begin(); it != shrinks0.end(); ++it)
-                    ret.push_back(tuple_type(*it, boost::get<1>(x),
-                                boost::get<2>(x), boost::get<3>(x),
-                                boost::get<4>(x)));
-                for (typename std::vector<T1>::const_iterator it =
-                        shrinks1.begin(); it != shrinks1.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x), *it,
-                                boost::get<2>(x), boost::get<3>(x),
-                                boost::get<4>(x)));
-                for (typename std::vector<T2>::const_iterator it =
-                        shrinks2.begin(); it != shrinks2.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), *it, boost::get<3>(x),
-                                boost::get<4>(x)));
-                for (typename std::vector<T3>::const_iterator it =
-                        shrinks3.begin(); it != shrinks3.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x), *it,
-                                boost::get<4>(x)));
-                for (typename std::vector<T4>::const_iterator it =
-                        shrinks4.begin(); it != shrinks4.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x),
-                                boost::get<3>(x), *it));
-                return ret;
-            }
-
-        private:
-            const Generator<T0> m_gen0;
-            const Generator<T1> m_gen1;
-            const Generator<T2> m_gen2;
-            const Generator<T3> m_gen3;
-            const Generator<T4> m_gen4;
-    };
-
-    template<class T0, class T1, class T2, class T3>
-    class TupleGenerator<T0, T1, T2, T3, null_type,
-          null_type, null_type, null_type, null_type, null_type>
-    {
-            typedef boost::tuple<T0, T1, T2, T3> tuple_type;
-        public:
-            TupleGenerator(const Generator<T0> &g0, const Generator<T1> &g1,
-                    const Generator<T2> &g2, const Generator<T3> &g3) :
-                m_gen0(g0), m_gen1(g1), m_gen2(g2), m_gen3(g3)
-            {
-            }
-
-            tuple_type unGen(RngEngine &rng, std::size_t size)
-            {
-                return tuple_type(m_gen0.unGen(rng, size),
-                        m_gen1.unGen(rng, size), m_gen2.unGen(rng, size),
-                        m_gen3.unGen(rng, size));
-            }
-
-            std::vector<tuple_type> shrink(const tuple_type &x)
-            {
-                std::vector<T0> shrinks0 = m_gen0.shrink(boost::get<0>(x));
-                std::vector<T1> shrinks1 = m_gen1.shrink(boost::get<1>(x));
-                std::vector<T2> shrinks2 = m_gen2.shrink(boost::get<2>(x));
-                std::vector<T3> shrinks3 = m_gen3.shrink(boost::get<3>(x));
-                std::vector<tuple_type> ret;
-                ret.reserve(shrinks0.size() + shrinks1.size() +
-                        shrinks2.size() + shrinks3.size());
-                for (typename std::vector<T0>::const_iterator it =
-                        shrinks0.begin(); it != shrinks0.end(); ++it)
-                    ret.push_back(tuple_type(*it, boost::get<1>(x),
-                                boost::get<2>(x), boost::get<3>(x)));
-                for (typename std::vector<T1>::const_iterator it =
-                        shrinks1.begin(); it != shrinks1.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x), *it,
-                                boost::get<2>(x), boost::get<3>(x)));
-                for (typename std::vector<T2>::const_iterator it =
-                        shrinks2.begin(); it != shrinks2.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), *it, boost::get<3>(x)));
-                for (typename std::vector<T3>::const_iterator it =
-                        shrinks3.begin(); it != shrinks3.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), boost::get<2>(x), *it));
-                return ret;
-            }
-
-        private:
-            const Generator<T0> m_gen0;
-            const Generator<T1> m_gen1;
-            const Generator<T2> m_gen2;
-            const Generator<T3> m_gen3;
-    };
-
-    template<class T0, class T1, class T2>
-    class TupleGenerator<T0, T1, T2, null_type, null_type,
-          null_type, null_type, null_type, null_type, null_type>
-    {
-            typedef boost::tuple<T0, T1, T2> tuple_type;
-        public:
-            TupleGenerator(const Generator<T0> &g0, const Generator<T1> &g1,
-                    const Generator<T2> &g2) :
-                m_gen0(g0), m_gen1(g1), m_gen2(g2)
-            {
-            }
-
-            tuple_type unGen(RngEngine &rng, std::size_t size)
-            {
-                return tuple_type(m_gen0.unGen(rng, size),
-                        m_gen1.unGen(rng, size), m_gen2.unGen(rng, size));
-            }
-
-            std::vector<tuple_type> shrink(const tuple_type &x)
-            {
-                std::vector<T0> shrinks0 = m_gen0.shrink(boost::get<0>(x));
-                std::vector<T1> shrinks1 = m_gen1.shrink(boost::get<1>(x));
-                std::vector<T2> shrinks2 = m_gen2.shrink(boost::get<2>(x));
-                std::vector<tuple_type> ret;
-                ret.reserve(shrinks0.size() + shrinks1.size() +
-                        shrinks2.size());
-                for (typename std::vector<T0>::const_iterator it =
-                        shrinks0.begin(); it != shrinks0.end(); ++it)
-                    ret.push_back(tuple_type(*it, boost::get<1>(x),
-                                boost::get<2>(x)));
-                for (typename std::vector<T1>::const_iterator it =
-                        shrinks1.begin(); it != shrinks1.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x), *it,
-                                boost::get<2>(x)));
-                for (typename std::vector<T2>::const_iterator it =
-                        shrinks2.begin(); it != shrinks2.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x),
-                                boost::get<1>(x), *it));
-                return ret;
-            }
-
-        private:
-            const Generator<T0> m_gen0;
-            const Generator<T1> m_gen1;
-            const Generator<T2> m_gen2;
-    };
-
-    template<class T0, class T1>
-    class TupleGenerator<T0, T1, null_type, null_type, null_type,
-          null_type, null_type, null_type, null_type, null_type>
-    {
-            typedef boost::tuple<T0, T1> tuple_type;
-        public:
-            TupleGenerator(const Generator<T0> &g0, const Generator<T1> &g1) :
-                m_gen0(g0), m_gen1(g1)
-            {
-            }
-
-            tuple_type unGen(RngEngine &rng, std::size_t size)
-            {
-                return tuple_type(m_gen0.unGen(rng, size),
-                        m_gen1.unGen(rng, size));
-            }
-
-            std::vector<tuple_type> shrink(const tuple_type &x)
-            {
-                std::vector<T0> shrinks0 = m_gen0.shrink(boost::get<0>(x));
-                std::vector<T1> shrinks1 = m_gen1.shrink(boost::get<1>(x));
-                std::vector<tuple_type> ret;
-                ret.reserve(shrinks0.size() + shrinks1.size());
-                for (typename std::vector<T0>::const_iterator it =
-                        shrinks0.begin(); it != shrinks0.end(); ++it)
-                    ret.push_back(tuple_type(*it, boost::get<1>(x)));
-                for (typename std::vector<T1>::const_iterator it =
-                        shrinks1.begin(); it != shrinks1.end(); ++it)
-                    ret.push_back(tuple_type(boost::get<0>(x), *it));
-                return ret;
-            }
-
-        private:
-            const Generator<T0> m_gen0;
-            const Generator<T1> m_gen1;
-    };
-
-    template<class T0>
-    class TupleGenerator<T0, null_type, null_type, null_type, null_type,
-          null_type, null_type, null_type, null_type, null_type>
-    {
-            typedef boost::tuple<T0> tuple_type;
-        public:
-            TupleGenerator(const Generator<T0> &g0) :
-                m_gen0(g0)
-            {
-            }
-
-            tuple_type unGen(RngEngine &rng, std::size_t size)
-            {
-                return tuple_type(m_gen0.unGen(rng, size));
-            }
-
-            std::vector<tuple_type> shrink(const tuple_type &x)
-            {
-                std::vector<T0> shrinks0 = m_gen0.shrink(boost::get<0>(x));
-                std::vector<tuple_type> ret;
-                ret.reserve(shrinks0.size());
-                for (typename std::vector<T0>::const_iterator it =
-                        shrinks0.begin(); it != shrinks0.end(); ++it)
-                    ret.push_back(tuple_type(*it));
-                return ret;
-            }
-
-        private:
-            const Generator<T0> m_gen0;
-    };
 }
 
-template<class T0>
-Generator<boost::tuple<T0> >
-tupleOf(const Generator<T0> &g0 = Arbitrary<T0>())
+template<typename... T>
+Generator<std::tuple<T...>> tupleOf(const Generator<T> &...g)
 {
-    return detail::TupleGenerator<T0>(g0);
+    return detail::TupleGenerator<T...>(g...);
 }
 
-template<class T0, class T1>
-Generator<boost::tuple<T0, T1> >
-tupleOf(const Generator<T0> &g0 = Arbitrary<T0>(),
-        const Generator<T1> &g1 = Arbitrary<T1>())
+template<typename... T>
+Generator<std::tuple<T...>> tupleOf()
 {
-    return detail::TupleGenerator<T0, T1>(g0, g1);
+    return detail::TupleGenerator<T...>(Arbitrary<T>()...);
 }
 
-template<class T0, class T1, class T2>
-Generator<boost::tuple<T0, T1, T2> >
-tupleOf(const Generator<T0> &g0 = Arbitrary<T0>(),
-        const Generator<T1> &g1 = Arbitrary<T1>(),
-        const Generator<T2> &g2 = Arbitrary<T2>())
-{
-    return detail::TupleGenerator<T0, T1, T2>(g0, g1, g2);
-}
-
-template<class T0, class T1, class T2, class T3>
-Generator<boost::tuple<T0, T1, T2, T3> >
-tupleOf(const Generator<T0> &g0 = Arbitrary<T0>(),
-        const Generator<T1> &g1 = Arbitrary<T1>(),
-        const Generator<T2> &g2 = Arbitrary<T2>(),
-        const Generator<T3> &g3 = Arbitrary<T3>())
-{
-    return detail::TupleGenerator<T0, T1, T2, T3>(g0, g1, g2, g3);
-}
-
-template<class T0, class T1, class T2, class T3, class T4>
-Generator<boost::tuple<T0, T1, T2, T3, T4> >
-tupleOf(const Generator<T0> &g0 = Arbitrary<T0>(),
-        const Generator<T1> &g1 = Arbitrary<T1>(),
-        const Generator<T2> &g2 = Arbitrary<T2>(),
-        const Generator<T3> &g3 = Arbitrary<T3>(),
-        const Generator<T4> &g4 = Arbitrary<T4>())
-{
-    return detail::TupleGenerator<T0, T1, T2, T3, T4>(g0, g1, g2, g3, g4);
-}
-
-template<class T0, class T1, class T2, class T3, class T4, class T5>
-Generator<boost::tuple<T0, T1, T2, T3, T4, T5> >
-tupleOf(const Generator<T0> &g0 = Arbitrary<T0>(),
-        const Generator<T1> &g1 = Arbitrary<T1>(),
-        const Generator<T2> &g2 = Arbitrary<T2>(),
-        const Generator<T3> &g3 = Arbitrary<T3>(),
-        const Generator<T4> &g4 = Arbitrary<T4>(),
-        const Generator<T5> &g5 = Arbitrary<T5>())
-{
-    return detail::TupleGenerator<T0, T1, T2, T3, T4, T5>(
-            g0, g1, g2, g3, g4, g5);
-}
-
-template<class T0, class T1, class T2, class T3, class T4, class T5, class T6>
-Generator<boost::tuple<T0, T1, T2, T3, T4, T5, T6> >
-tupleOf(const Generator<T0> &g0 = Arbitrary<T0>(),
-        const Generator<T1> &g1 = Arbitrary<T1>(),
-        const Generator<T2> &g2 = Arbitrary<T2>(),
-        const Generator<T3> &g3 = Arbitrary<T3>(),
-        const Generator<T4> &g4 = Arbitrary<T4>(),
-        const Generator<T5> &g5 = Arbitrary<T5>(),
-        const Generator<T6> &g6 = Arbitrary<T6>())
-{
-    return detail::TupleGenerator<T0, T1, T2, T3, T4, T5, T6>(
-            g0, g1, g2, g3, g4, g5, g6);
-}
-
-template<class T0, class T1, class T2, class T3, class T4,
-    class T5, class T6, class T7>
-Generator<boost::tuple<T0, T1, T2, T3, T4, T5, T6, T7> >
-tupleOf(const Generator<T0> &g0 = Arbitrary<T0>(),
-        const Generator<T1> &g1 = Arbitrary<T1>(),
-        const Generator<T2> &g2 = Arbitrary<T2>(),
-        const Generator<T3> &g3 = Arbitrary<T3>(),
-        const Generator<T4> &g4 = Arbitrary<T4>(),
-        const Generator<T5> &g5 = Arbitrary<T5>(),
-        const Generator<T6> &g6 = Arbitrary<T6>(),
-        const Generator<T7> &g7 = Arbitrary<T7>())
-{
-    return detail::TupleGenerator<T0, T1, T2, T3, T4, T5, T6, T7>(
-            g0, g1, g2, g3, g4, g5, g6, g7);
-}
-
-template<class T0, class T1, class T2, class T3, class T4,
-    class T5, class T6, class T7, class T8>
-Generator<boost::tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8> >
-tupleOf(const Generator<T0> &g0 = Arbitrary<T0>(),
-        const Generator<T1> &g1 = Arbitrary<T1>(),
-        const Generator<T2> &g2 = Arbitrary<T2>(),
-        const Generator<T3> &g3 = Arbitrary<T3>(),
-        const Generator<T4> &g4 = Arbitrary<T4>(),
-        const Generator<T5> &g5 = Arbitrary<T5>(),
-        const Generator<T6> &g6 = Arbitrary<T6>(),
-        const Generator<T7> &g7 = Arbitrary<T7>(),
-        const Generator<T8> &g8 = Arbitrary<T8>())
-{
-    return detail::TupleGenerator<T0, T1, T2, T3, T4, T5, T6, T7, T8>(
-            g0, g1, g2, g3, g4, g5, g6, g7, g8);
-}
-
-template<class T0, class T1, class T2, class T3, class T4,
-    class T5, class T6, class T7, class T8, class T9>
-Generator<boost::tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8> >
-tupleOf(const Generator<T0> &g0 = Arbitrary<T0>(),
-        const Generator<T1> &g1 = Arbitrary<T1>(),
-        const Generator<T2> &g2 = Arbitrary<T2>(),
-        const Generator<T3> &g3 = Arbitrary<T3>(),
-        const Generator<T4> &g4 = Arbitrary<T4>(),
-        const Generator<T5> &g5 = Arbitrary<T5>(),
-        const Generator<T6> &g6 = Arbitrary<T6>(),
-        const Generator<T7> &g7 = Arbitrary<T7>(),
-        const Generator<T8> &g8 = Arbitrary<T8>(),
-        const Generator<T9> &g9 = Arbitrary<T9>())
-{
-    return detail::TupleGenerator<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
-            g0, g1, g2, g3, g4, g5, g6, g7, g8, g9);
-}
-
-
-
+    
 }
 
 #endif

--- a/include/cppqc/Generator.h
+++ b/include/cppqc/Generator.h
@@ -1277,7 +1277,7 @@ namespace detail {
                 shrinkOutput.push_back(std::move(copiedShrinkInput));
             }
 
-            // continue recursion (for right to left)
+            // continue recursion (from right to left)
             TupleGeneratorHelper_shrink<offset - 1, T...>::appendShrinks(
                 shrinkInput, shrinkOutput, generators);
         }

--- a/include/cppqc/Property.h
+++ b/include/cppqc/Property.h
@@ -31,6 +31,10 @@
 
 namespace cppqc {
 
+namespace detail {
+    struct null_type {};
+}
+
 class PropertyBase
 {
     public:
@@ -50,7 +54,7 @@ template<class T0, class T1 = detail::null_type, class T2 = detail::null_type,
 class Property : public PropertyBase
 {
     public:
-        typedef boost::tuple<T0, T1, T2, T3, T4> Input;
+        typedef std::tuple<T0, T1, T2, T3, T4> Input;
 
         Property(const Generator<T0> &g0 = Arbitrary<T0>(),
                 const Generator<T1> &g1 = Arbitrary<T1>(),
@@ -71,18 +75,18 @@ class Property : public PropertyBase
         }
         bool trivialInput(const Input &in) const
         {
-            return trivial(boost::get<0>(in), boost::get<1>(in),
-                    boost::get<2>(in), boost::get<3>(in), boost::get<4>(in));
+            return trivial(std::get<0>(in), std::get<1>(in),
+                    std::get<2>(in), std::get<3>(in), std::get<4>(in));
         }
         std::string classifyInput(const Input &in) const
         {
-            return classify(boost::get<0>(in), boost::get<1>(in),
-                    boost::get<2>(in), boost::get<3>(in), boost::get<4>(in));
+            return classify(std::get<0>(in), std::get<1>(in),
+                    std::get<2>(in), std::get<3>(in), std::get<4>(in));
         }
         bool checkInput(const Input &in) const
         {
-            return check(boost::get<0>(in), boost::get<1>(in),
-                    boost::get<2>(in), boost::get<3>(in), boost::get<4>(in));
+            return check(std::get<0>(in), std::get<1>(in),
+                    std::get<2>(in), std::get<3>(in), std::get<4>(in));
         }
 
     private:
@@ -110,7 +114,7 @@ class Property<T0, detail::null_type, detail::null_type, detail::null_type,
       detail::null_type> : public PropertyBase
 {
     public:
-        typedef boost::tuple<T0> Input;
+        typedef std::tuple<T0> Input;
 
         Property(const Generator<T0> &g0 = Arbitrary<T0>()) :
             m_gen(tupleOf(g0))
@@ -127,15 +131,15 @@ class Property<T0, detail::null_type, detail::null_type, detail::null_type,
         }
         bool trivialInput(const Input &in) const
         {
-            return trivial(boost::get<0>(in));
+            return trivial(std::get<0>(in));
         }
         std::string classifyInput(const Input &in) const
         {
-            return classify(boost::get<0>(in));
+            return classify(std::get<0>(in));
         }
         bool checkInput(const Input &in) const
         {
-            return check(boost::get<0>(in));
+            return check(std::get<0>(in));
         }
 
     private:
@@ -160,7 +164,7 @@ class Property<T0, T1, detail::null_type, detail::null_type,
       detail::null_type> : public PropertyBase
 {
     public:
-        typedef boost::tuple<T0, T1> Input;
+        typedef std::tuple<T0, T1> Input;
 
         Property(const Generator<T0> &g0 = Arbitrary<T0>(),
                 const Generator<T1> &g1 = Arbitrary<T1>()) :
@@ -178,15 +182,15 @@ class Property<T0, T1, detail::null_type, detail::null_type,
         }
         bool trivialInput(const Input &in) const
         {
-            return trivial(boost::get<0>(in), boost::get<1>(in));
+            return trivial(std::get<0>(in), std::get<1>(in));
         }
         std::string classifyInput(const Input &in) const
         {
-            return classify(boost::get<0>(in), boost::get<1>(in));
+            return classify(std::get<0>(in), std::get<1>(in));
         }
         bool checkInput(const Input &in) const
         {
-            return check(boost::get<0>(in), boost::get<1>(in));
+            return check(std::get<0>(in), std::get<1>(in));
         }
 
     private:
@@ -211,7 +215,7 @@ class Property<T0, T1, T2, detail::null_type, detail::null_type> :
     public PropertyBase
 {
     public:
-        typedef boost::tuple<T0, T1, T2> Input;
+        typedef std::tuple<T0, T1, T2> Input;
 
         Property(const Generator<T0> &g0 = Arbitrary<T0>(),
                 const Generator<T1> &g1 = Arbitrary<T1>(),
@@ -230,18 +234,18 @@ class Property<T0, T1, T2, detail::null_type, detail::null_type> :
         }
         bool trivialInput(const Input &in) const
         {
-            return trivial(boost::get<0>(in), boost::get<1>(in),
-                    boost::get<2>(in));
+            return trivial(std::get<0>(in), std::get<1>(in),
+                    std::get<2>(in));
         }
         std::string classifyInput(const Input &in) const
         {
-            return classify(boost::get<0>(in), boost::get<1>(in),
-                    boost::get<2>(in));
+            return classify(std::get<0>(in), std::get<1>(in),
+                    std::get<2>(in));
         }
         bool checkInput(const Input &in) const
         {
-            return check(boost::get<0>(in), boost::get<1>(in),
-                    boost::get<2>(in));
+            return check(std::get<0>(in), std::get<1>(in),
+                    std::get<2>(in));
         }
 
     private:
@@ -265,7 +269,7 @@ template<class T0, class T1, class T2, class T3>
 class Property<T0, T1, T2, T3, detail::null_type> : public PropertyBase
 {
     public:
-        typedef boost::tuple<T0, T1, T2, T3> Input;
+        typedef std::tuple<T0, T1, T2, T3> Input;
 
         Property(const Generator<T0> &g0 = Arbitrary<T0>(),
                 const Generator<T1> &g1 = Arbitrary<T1>(),
@@ -285,18 +289,18 @@ class Property<T0, T1, T2, T3, detail::null_type> : public PropertyBase
         }
         bool trivialInput(const Input &in) const
         {
-            return trivial(boost::get<0>(in), boost::get<1>(in),
-                    boost::get<2>(in), boost::get<3>(in));
+            return trivial(std::get<0>(in), std::get<1>(in),
+                    std::get<2>(in), std::get<3>(in));
         }
         std::string classifyInput(const Input &in) const
         {
-            return classify(boost::get<0>(in), boost::get<1>(in),
-                    boost::get<2>(in), boost::get<3>(in));
+            return classify(std::get<0>(in), std::get<1>(in),
+                    std::get<2>(in), std::get<3>(in));
         }
         bool checkInput(const Input &in) const
         {
-            return check(boost::get<0>(in), boost::get<1>(in),
-                    boost::get<2>(in), boost::get<3>(in));
+            return check(std::get<0>(in), std::get<1>(in),
+                    std::get<2>(in), std::get<3>(in));
         }
 
     private:
@@ -326,129 +330,129 @@ class Property<T0, T1, T2, T3, detail::null_type> : public PropertyBase
 // trivializeWith
 
     template<class T0>
-    std::ostream &printInput(std::ostream &out, const boost::tuple<T0> &in)
+    std::ostream &printInput(std::ostream &out, const std::tuple<T0> &in)
     {
-        return out << "  0: " << prettyPrint(boost::get<0>(in)) << '\n'
+        return out << "  0: " << prettyPrint(std::get<0>(in)) << '\n'
                    << std::flush;
     }
 
     template<class T0, class T1>
-    std::ostream &printInput(std::ostream &out, const boost::tuple<T0, T1> &in)
+    std::ostream &printInput(std::ostream &out, const std::tuple<T0, T1> &in)
     {
-        return out << "  0: " << prettyPrint(boost::get<0>(in)) << '\n'
-                   << "  1: " << prettyPrint(boost::get<1>(in)) << '\n'
+        return out << "  0: " << prettyPrint(std::get<0>(in)) << '\n'
+                   << "  1: " << prettyPrint(std::get<1>(in)) << '\n'
                    << std::flush;
     }
 
     template<class T0, class T1, class T2>
     std::ostream &printInput(std::ostream &out,
-            const boost::tuple<T0, T1, T2> &in)
+            const std::tuple<T0, T1, T2> &in)
     {
-        return out << "  0: " << prettyPrint(boost::get<0>(in)) << '\n'
-                   << "  1: " << prettyPrint(boost::get<1>(in)) << '\n'
-                   << "  2: " << prettyPrint(boost::get<2>(in)) << '\n'
+        return out << "  0: " << prettyPrint(std::get<0>(in)) << '\n'
+                   << "  1: " << prettyPrint(std::get<1>(in)) << '\n'
+                   << "  2: " << prettyPrint(std::get<2>(in)) << '\n'
                    << std::flush;
     }
 
     template<class T0, class T1, class T2, class T3>
     std::ostream &printInput(std::ostream &out,
-            const boost::tuple<T0, T1, T2, T3> &in)
+            const std::tuple<T0, T1, T2, T3> &in)
     {
-        return out << "  0: " << prettyPrint(boost::get<0>(in)) << '\n'
-                   << "  1: " << prettyPrint(boost::get<1>(in)) << '\n'
-                   << "  2: " << prettyPrint(boost::get<2>(in)) << '\n'
-                   << "  3: " << prettyPrint(boost::get<3>(in)) << '\n'
+        return out << "  0: " << prettyPrint(std::get<0>(in)) << '\n'
+                   << "  1: " << prettyPrint(std::get<1>(in)) << '\n'
+                   << "  2: " << prettyPrint(std::get<2>(in)) << '\n'
+                   << "  3: " << prettyPrint(std::get<3>(in)) << '\n'
                    << std::flush;
     }
 
     template<class T0, class T1, class T2, class T3, class T4>
     std::ostream &printInput(std::ostream &out,
-            const boost::tuple<T0, T1, T2, T3, T4> &in)
+            const std::tuple<T0, T1, T2, T3, T4> &in)
     {
-        return out << "  0: " << prettyPrint(boost::get<0>(in)) << '\n'
-                   << "  1: " << prettyPrint(boost::get<1>(in)) << '\n'
-                   << "  2: " << prettyPrint(boost::get<2>(in)) << '\n'
-                   << "  3: " << prettyPrint(boost::get<3>(in)) << '\n'
-                   << "  4: " << prettyPrint(boost::get<4>(in)) << '\n'
+        return out << "  0: " << prettyPrint(std::get<0>(in)) << '\n'
+                   << "  1: " << prettyPrint(std::get<1>(in)) << '\n'
+                   << "  2: " << prettyPrint(std::get<2>(in)) << '\n'
+                   << "  3: " << prettyPrint(std::get<3>(in)) << '\n'
+                   << "  4: " << prettyPrint(std::get<4>(in)) << '\n'
                    << std::flush;
     }
 
     template<class T0, class T1, class T2, class T3, class T4, class T5>
     std::ostream &printInput(std::ostream &out,
-            const boost::tuple<T0, T1, T2, T3, T4, T5> &in)
+            const std::tuple<T0, T1, T2, T3, T4, T5> &in)
     {
-        return out << "  0: " << prettyPrint(boost::get<0>(in)) << '\n'
-                   << "  1: " << prettyPrint(boost::get<1>(in)) << '\n'
-                   << "  2: " << prettyPrint(boost::get<2>(in)) << '\n'
-                   << "  3: " << prettyPrint(boost::get<3>(in)) << '\n'
-                   << "  4: " << prettyPrint(boost::get<4>(in)) << '\n'
-                   << "  5: " << prettyPrint(boost::get<5>(in)) << '\n'
+        return out << "  0: " << prettyPrint(std::get<0>(in)) << '\n'
+                   << "  1: " << prettyPrint(std::get<1>(in)) << '\n'
+                   << "  2: " << prettyPrint(std::get<2>(in)) << '\n'
+                   << "  3: " << prettyPrint(std::get<3>(in)) << '\n'
+                   << "  4: " << prettyPrint(std::get<4>(in)) << '\n'
+                   << "  5: " << prettyPrint(std::get<5>(in)) << '\n'
                    << std::flush;
     }
 
     template<class T0, class T1, class T2, class T3, class T4,
         class T5, class T6>
     std::ostream &printInput(std::ostream &out,
-            const boost::tuple<T0, T1, T2, T3, T4, T5, T6> &in)
+            const std::tuple<T0, T1, T2, T3, T4, T5, T6> &in)
     {
-        return out << "  0: " << prettyPrint(boost::get<0>(in)) << '\n'
-                   << "  1: " << prettyPrint(boost::get<1>(in)) << '\n'
-                   << "  2: " << prettyPrint(boost::get<2>(in)) << '\n'
-                   << "  3: " << prettyPrint(boost::get<3>(in)) << '\n'
-                   << "  4: " << prettyPrint(boost::get<4>(in)) << '\n'
-                   << "  5: " << prettyPrint(boost::get<5>(in)) << '\n'
-                   << "  6: " << prettyPrint(boost::get<6>(in)) << '\n'
+        return out << "  0: " << prettyPrint(std::get<0>(in)) << '\n'
+                   << "  1: " << prettyPrint(std::get<1>(in)) << '\n'
+                   << "  2: " << prettyPrint(std::get<2>(in)) << '\n'
+                   << "  3: " << prettyPrint(std::get<3>(in)) << '\n'
+                   << "  4: " << prettyPrint(std::get<4>(in)) << '\n'
+                   << "  5: " << prettyPrint(std::get<5>(in)) << '\n'
+                   << "  6: " << prettyPrint(std::get<6>(in)) << '\n'
                    << std::flush;
     }
 
     template<class T0, class T1, class T2, class T3, class T4,
         class T5, class T6, class T7>
     std::ostream &printInput(std::ostream &out,
-            const boost::tuple<T0, T1, T2, T3, T4, T5, T6, T7> &in)
+            const std::tuple<T0, T1, T2, T3, T4, T5, T6, T7> &in)
     {
-        return out << "  0: " << prettyPrint(boost::get<0>(in)) << '\n'
-                   << "  1: " << prettyPrint(boost::get<1>(in)) << '\n'
-                   << "  2: " << prettyPrint(boost::get<2>(in)) << '\n'
-                   << "  3: " << prettyPrint(boost::get<3>(in)) << '\n'
-                   << "  4: " << prettyPrint(boost::get<4>(in)) << '\n'
-                   << "  5: " << prettyPrint(boost::get<5>(in)) << '\n'
-                   << "  6: " << prettyPrint(boost::get<6>(in)) << '\n'
-                   << "  7: " << prettyPrint(boost::get<7>(in)) << '\n'
+        return out << "  0: " << prettyPrint(std::get<0>(in)) << '\n'
+                   << "  1: " << prettyPrint(std::get<1>(in)) << '\n'
+                   << "  2: " << prettyPrint(std::get<2>(in)) << '\n'
+                   << "  3: " << prettyPrint(std::get<3>(in)) << '\n'
+                   << "  4: " << prettyPrint(std::get<4>(in)) << '\n'
+                   << "  5: " << prettyPrint(std::get<5>(in)) << '\n'
+                   << "  6: " << prettyPrint(std::get<6>(in)) << '\n'
+                   << "  7: " << prettyPrint(std::get<7>(in)) << '\n'
                    << std::flush;
     }
 
     template<class T0, class T1, class T2, class T3, class T4,
         class T5, class T6, class T7, class T8>
     std::ostream &printInput(std::ostream &out,
-            const boost::tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8> &in)
+            const std::tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8> &in)
     {
-        return out << "  0: " << prettyPrint(boost::get<0>(in)) << '\n'
-                   << "  1: " << prettyPrint(boost::get<1>(in)) << '\n'
-                   << "  2: " << prettyPrint(boost::get<2>(in)) << '\n'
-                   << "  3: " << prettyPrint(boost::get<3>(in)) << '\n'
-                   << "  4: " << prettyPrint(boost::get<4>(in)) << '\n'
-                   << "  5: " << prettyPrint(boost::get<5>(in)) << '\n'
-                   << "  6: " << prettyPrint(boost::get<6>(in)) << '\n'
-                   << "  7: " << prettyPrint(boost::get<7>(in)) << '\n'
-                   << "  8: " << prettyPrint(boost::get<8>(in)) << '\n'
+        return out << "  0: " << prettyPrint(std::get<0>(in)) << '\n'
+                   << "  1: " << prettyPrint(std::get<1>(in)) << '\n'
+                   << "  2: " << prettyPrint(std::get<2>(in)) << '\n'
+                   << "  3: " << prettyPrint(std::get<3>(in)) << '\n'
+                   << "  4: " << prettyPrint(std::get<4>(in)) << '\n'
+                   << "  5: " << prettyPrint(std::get<5>(in)) << '\n'
+                   << "  6: " << prettyPrint(std::get<6>(in)) << '\n'
+                   << "  7: " << prettyPrint(std::get<7>(in)) << '\n'
+                   << "  8: " << prettyPrint(std::get<8>(in)) << '\n'
                    << std::flush;
     }
 
     template<class T0, class T1, class T2, class T3, class T4,
         class T5, class T6, class T7, class T8, class T9>
     std::ostream &printInput(std::ostream &out,
-            const boost::tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> &in)
+            const std::tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> &in)
     {
-        return out << "  0: " << prettyPrint(boost::get<0>(in)) << '\n'
-                   << "  1: " << prettyPrint(boost::get<1>(in)) << '\n'
-                   << "  2: " << prettyPrint(boost::get<2>(in)) << '\n'
-                   << "  3: " << prettyPrint(boost::get<3>(in)) << '\n'
-                   << "  4: " << prettyPrint(boost::get<4>(in)) << '\n'
-                   << "  5: " << prettyPrint(boost::get<5>(in)) << '\n'
-                   << "  6: " << prettyPrint(boost::get<6>(in)) << '\n'
-                   << "  7: " << prettyPrint(boost::get<7>(in)) << '\n'
-                   << "  8: " << prettyPrint(boost::get<8>(in)) << '\n'
-                   << "  9: " << prettyPrint(boost::get<9>(in)) << '\n'
+        return out << "  0: " << prettyPrint(std::get<0>(in)) << '\n'
+                   << "  1: " << prettyPrint(std::get<1>(in)) << '\n'
+                   << "  2: " << prettyPrint(std::get<2>(in)) << '\n'
+                   << "  3: " << prettyPrint(std::get<3>(in)) << '\n'
+                   << "  4: " << prettyPrint(std::get<4>(in)) << '\n'
+                   << "  5: " << prettyPrint(std::get<5>(in)) << '\n'
+                   << "  6: " << prettyPrint(std::get<6>(in)) << '\n'
+                   << "  7: " << prettyPrint(std::get<7>(in)) << '\n'
+                   << "  8: " << prettyPrint(std::get<8>(in)) << '\n'
+                   << "  9: " << prettyPrint(std::get<9>(in)) << '\n'
                    << std::flush;
     }
 


### PR DESCRIPTION
- Reduced code size of TupleGenerator by using variadic templates
- Replaced boost::tuple by std::tuple

Note: std::tuple is now no longer supported out of the box.
The BoostTupleSupport example shows how to restore that support.