### PR TITLE
Add support for std::initializer_list for elements generator

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,6 +13,9 @@ target_link_libraries(testReverseArray cppqc)
 add_executable(testSort src/TestSort.cpp)
 target_link_libraries(testSort cppqc)
 
+add_executable(exampleElementsGen src/exampleElementsGen.cpp)
+target_link_libraries(exampleElementsGen cppqc)
+
 # requires c++1y compile flag
 #add_executable(testBoostTupleSupport src/BoostTupleSupport.cpp)
 #target_link_libraries(testBoostTupleSupport cppqc)

--- a/examples/src/exampleElementsGen.cpp
+++ b/examples/src/exampleElementsGen.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2010, Gregory Rogers All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cppqc.h"
+
+#include <algorithm>
+#include <sstream>
+
+// Useless property just to show usage of elements generator
+
+struct PropTestElementsGen : cppqc::Property<int>
+{
+    PropTestElementsGen() : Property(cppqc::elements({1, 4, 5})) {}
+    bool check(const int &v) const override
+    {
+        return (v == 1) || (v == 4) || (v == 5);
+    }
+    std::string name() const override
+    {
+        return "TestElementsGen";
+    }
+    std::string classify(const int &v) const override
+    {
+        std::ostringstream sstr;
+        sstr << v;
+        return sstr.str();
+    }
+};
+
+int main()
+{
+    cppqc::quickCheckOutput(PropTestElementsGen());
+}

--- a/include/cppqc/Generator.h
+++ b/include/cppqc/Generator.h
@@ -763,6 +763,13 @@ namespace detail {
     class ElementsGenerator
     {
         public:
+            ElementsGenerator &operator()(const std::initializer_list<T> x)
+            {
+                for (auto &i: x)
+                    m_elems.push_back(i);
+                return *this;
+            }
+
             ElementsGenerator &operator()(const T &x)
             {
                 m_elems.push_back(x);
@@ -792,6 +799,13 @@ namespace detail {
 }
 
 /// Generates one of the given values.
+template<class T>
+detail::ElementsGenerator<T> elements(const std::initializer_list<T> x)
+{
+    detail::ElementsGenerator<T> ret;
+    return ret(x);
+}
+
 template<class T>
 detail::ElementsGenerator<T> elements(const T &x)
 {


### PR DESCRIPTION
Add support for std::initializer_list as parameter for elements generator since it's convenient way to declare set of elements. Please see added example.