### PR TITLE
A compact way how to write cppqc tests

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,6 +13,9 @@ target_link_libraries(testReverseArray cppqc)
 add_executable(testSort src/TestSort.cpp)
 target_link_libraries(testSort cppqc)
 
+add_executable(testSortCompact src/TestSortCompact.cpp)
+target_link_libraries(testSortCompact cppqc)
+
 add_executable(testChooseGenerator src/TestChooseGenerator.cpp)
 target_link_libraries(testChooseGenerator cppqc)
 
@@ -22,5 +25,3 @@ target_link_libraries(exampleElementsGen cppqc)
 # requires c++1y compile flag
 #add_executable(testBoostTupleSupport src/BoostTupleSupport.cpp)
 #target_link_libraries(testBoostTupleSupport cppqc)
-
-

--- a/examples/src/TestSortCompact.cpp
+++ b/examples/src/TestSortCompact.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016, Vladimir Strisovsky All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cppqc.h"
+#include "cppqc/CompactCheck.h"
+
+#include <algorithm>
+#include <iterator>
+#include <boost/static_assert.hpp>
+#include <sstream>
+
+namespace uut {
+
+template <typename InputIterator>
+void selection_sort(InputIterator b, InputIterator e, bool make_mistakes = false)
+{
+    //Selection sort performs the following steps:
+    //1) From the current iterator, find the smallest value
+    //2) Swap the smallest value with the current iterator
+    //3) Continue until end of range
+
+    make_mistakes && b != e ? ++b : b;
+    for(InputIterator c = b; c != e ; ++c)
+    {
+        std::swap(*(std::min_element(c, e)), *c);
+    }
+}
+
+}
+
+int main()
+{
+    cppqc::gen<std::vector<int>>()
+        .property("Sorting should be sorted",
+            [](const std::vector<int> &v)
+            {
+                std::vector<int> v_copy(v);
+                uut::selection_sort(std::begin(v_copy), std::end(v_copy), true);
+                return std::is_sorted(std::begin(v_copy), std::end(v_copy));
+            })
+        .classify([](const std::vector<int> &v)
+            {
+                return std::to_string(v.size());
+            })
+        .trivial([](const std::vector<int> &v)
+            {
+                return v.empty() || v.size() == 1;
+            })
+        .testWithOutput();
+}

--- a/examples/src/TestSortCompact.cpp
+++ b/examples/src/TestSortCompact.cpp
@@ -52,6 +52,8 @@ void selection_sort(InputIterator b, InputIterator e, bool make_mistakes = false
 
 int main()
 {
+    std::cout << "* uut::selection_sort" << std::endl;
+
     cppqc::gen<std::vector<int>>()
         .property("Sorting should be sorted",
             [](const std::vector<int> &v)
@@ -69,4 +71,25 @@ int main()
                 return v.empty() || v.size() == 1;
             })
         .testWithOutput();
+
+    std::cout << "* std::sort" << std::endl;
+
+    cppqc::gen<std::vector<int>>()
+        .property("Sorting should be sorted",
+            [](const std::vector<int> &v)
+            {
+                std::vector<int> v_copy(v);
+                std::sort(v_copy.begin(), v_copy.end());
+                return std::is_sorted(std::begin(v_copy), std::end(v_copy));
+            })
+        .classify([](const std::vector<int> &v)
+            {
+                return std::to_string(v.size());
+            })
+        .trivial([](const std::vector<int> &v)
+            {
+                return v.empty() || v.size() == 1;
+            })
+        .testWithOutput();
+
 }

--- a/include/cppqc/CompactCheck.h
+++ b/include/cppqc/CompactCheck.h
@@ -1,0 +1,125 @@
+#include "Test.h"
+
+namespace cppqc
+{
+
+template<typename Function>
+struct CompactCheckFunction
+{
+    using type = Function;
+    using FunctionT = Function;
+    static const bool valid = true;
+
+    template<typename ReturnType, typename ... T>
+    static ReturnType apply(const Function& fnc, ReturnType, const T& ... v)
+    {
+        return fnc(v ...);
+    }
+};
+
+template<>
+struct CompactCheckFunction<void>
+{
+    using type = void;
+    using FunctionT = void*;
+    static const bool valid = false;
+
+    template<typename Function, typename ReturnType, typename ... T>
+    static ReturnType apply(const Function& fnc, ReturnType r, const T& ... v)
+    {
+        return r;
+    }
+};
+
+template<typename CheckFunction, typename TrivialFunction, typename ClassifyFunction, typename ... T>
+class CompactCheck : public Property<T ...>
+{
+    std::string m_name;
+
+    template<typename _CheckFunction, typename _TrivialFunction, typename _ClassifyFunction, typename ... _T>
+    friend class CompactCheck;
+
+    using CheckFunctionT = CompactCheckFunction<CheckFunction>;
+    typename CheckFunctionT::FunctionT m_checkFnc;
+
+    using TrivialFunctionT = CompactCheckFunction<TrivialFunction>;
+    typename TrivialFunctionT::FunctionT m_trivialFnc;
+
+    using ClassifyFunctionT = CompactCheckFunction<ClassifyFunction>;
+    typename ClassifyFunctionT::FunctionT m_classifyFnc;
+
+    CompactCheck( std::string name,
+                  typename CheckFunctionT::FunctionT&& checkFunction,
+                  typename TrivialFunctionT::FunctionT&& trivialFunctions,
+                  typename ClassifyFunctionT::FunctionT&& classifyFunction)
+    : m_name(name)
+    , m_checkFnc(checkFunction)
+    , m_trivialFnc(trivialFunctions)
+    , m_classifyFnc(classifyFunction)
+    {}
+
+      bool check(const T& ... v) const override
+      {
+          return CheckFunctionT::apply(m_checkFnc, true, v ...);
+      }
+
+      bool trivial(const T& ... v) const override
+      {
+        return TrivialFunctionT::apply(m_trivialFnc, false, v ...);
+      }
+
+      std::string classify(const T& ... v) const override
+      {
+        return ClassifyFunctionT::apply(m_classifyFnc, std::string(), v ...);
+      }
+
+      std::string name() const
+      {
+          return m_name.empty() ? "no-name" : m_name;
+      }
+
+public:
+    CompactCheck()
+    {}
+
+    template<typename _CheckFunction>
+    CompactCheck<_CheckFunction, typename TrivialFunctionT::type, typename ClassifyFunctionT::type, T ...> property(const std::string& name, _CheckFunction&& checkFnc)
+    {
+        static_assert(CheckFunctionT::valid == false, "Check function is already set");
+        return CompactCheck<_CheckFunction, typename TrivialFunctionT::type, typename ClassifyFunctionT::type, T ...>(name, std::move(checkFnc), std::move(m_trivialFnc), std::move(m_classifyFnc));
+    }
+
+    template<typename _TrivialFunction>
+    CompactCheck<typename CheckFunctionT::type, _TrivialFunction, typename ClassifyFunctionT::type, T ...> trivial(_TrivialFunction&& trivialFnc)
+    {
+        static_assert(TrivialFunctionT::valid == false, "Trivial function is already set");
+        return CompactCheck<typename CheckFunctionT::type, _TrivialFunction, typename ClassifyFunctionT::type, T ...>(std::move(m_name), std::move(m_checkFnc), std::move(trivialFnc), std::move(m_classifyFnc));
+    }
+
+    template<typename _ClassifyFunction>
+    CompactCheck<typename CheckFunctionT::type, typename TrivialFunctionT::type, _ClassifyFunction, T ...> classify(_ClassifyFunction&& classifyFnc)
+    {
+        static_assert(ClassifyFunctionT::valid == false, "Classsify function is already set");
+        return CompactCheck<typename CheckFunctionT::type, typename TrivialFunctionT::type, _ClassifyFunction, T ...>(std::move(m_name), std::move(m_checkFnc), std::move(m_trivialFnc), std::move(classifyFnc));
+    }
+
+    Result test( std::size_t maxSuccess = 100, std::size_t maxDiscarded = 0, std::size_t maxSize = 0)
+    {
+        return quickCheck(*this, maxSuccess, maxDiscarded, maxSize);
+    }
+
+    Result testWithOutput( std::ostream &out = std::cout,  std::size_t maxSuccess = 100, std::size_t maxDiscarded = 0, std::size_t maxSize = 0)
+    {
+        return quickCheckOutput(*this, out, maxSuccess, maxDiscarded, maxSize);
+    }
+};
+
+template<typename ... T>
+CompactCheck<void, void, void, T ...> gen()
+{
+    return CompactCheck<void, void, void, T ...>();
+}
+
+
+
+}

--- a/include/cppqc/CompactCheck.h
+++ b/include/cppqc/CompactCheck.h
@@ -24,6 +24,7 @@
  */
 
 #include "Test.h"
+#include "Arbitrary.h"
 
 namespace cppqc
 {
@@ -83,28 +84,32 @@ class CompactCheck : public Property<T ...>
     , m_classifyFnc(classifyFunction)
     {}
 
-      bool check(const T& ... v) const override
-      {
-          return CheckFunctionT::apply(m_checkFnc, true, v ...);
-      }
+    bool check(const T& ... v) const override
+    {
+        return CheckFunctionT::apply(m_checkFnc, true, v ...);
+    }
 
-      bool trivial(const T& ... v) const override
-      {
-        return TrivialFunctionT::apply(m_trivialFnc, false, v ...);
-      }
+    bool trivial(const T& ... v) const override
+    {
+      return TrivialFunctionT::apply(m_trivialFnc, false, v ...);
+    }
 
-      std::string classify(const T& ... v) const override
-      {
-        return ClassifyFunctionT::apply(m_classifyFnc, std::string(), v ...);
-      }
+    std::string classify(const T& ... v) const override
+    {
+      return ClassifyFunctionT::apply(m_classifyFnc, std::string(), v ...);
+    }
 
-      std::string name() const
-      {
-          return m_name.empty() ? "no-name" : m_name;
-      }
+    std::string name() const
+    {
+        return m_name.empty() ? "no-name" : m_name;
+    }
 
 public:
     CompactCheck()
+    {}
+
+    CompactCheck(const Generator<T>& ... g)
+    : Property<T ...>(g ...)
     {}
 
     template<typename _CheckFunction>
@@ -145,6 +150,11 @@ CompactCheck<void, void, void, T ...> gen()
     return CompactCheck<void, void, void, T ...>();
 }
 
+template<typename ... T>
+CompactCheck<void, void, void, T ...> gen(const Generator<T>& ... g)
+{
+    return CompactCheck<void, void, void, T ...>(g ...);
+}
 
 
 }

--- a/include/cppqc/CompactCheck.h
+++ b/include/cppqc/CompactCheck.h
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2016, Vladimir Strisovsky All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include "Test.h"
 
 namespace cppqc


### PR DESCRIPTION
Added a compact way how to write cppqc tests. Declaration of structure which derive from Property is not needed.
Example:
```
    cppqc::gen<std::vector<int>>()
        .property("Sorting should be sorted",
            [](const std::vector<int> &v)
            {
                std::vector<int> v_copy(v);
                uut::selection_sort(std::begin(v_copy), std::end(v_copy), true);
                return std::is_sorted(std::begin(v_copy), std::end(v_copy));
            })
        .classify([](const std::vector<int> &v)
            {
                return std::to_string(v.size());
            })
        .trivial([](const std::vector<int> &v)
            {
                return v.empty() || v.size() == 1;
            })
        .testWithOutput();
```